### PR TITLE
Add setting to write out keys to file on success

### DIFF
--- a/akd-client.go
+++ b/akd-client.go
@@ -271,7 +271,7 @@ func main() {
         err = file.Chmod(0600)
         if err != nil {
             fmt.Fprintln(os.Stderr, "Failed to change file permissions on "+path)
-            err = nil // Failed permissions, but keep going to try ownership
+            // Failed permissions, but keep going to try ownership
         }
 
         // Mirror ownership of parent dir

--- a/akd-client.go
+++ b/akd-client.go
@@ -261,7 +261,11 @@ func main() {
         }
 
         // Write out the keys
-        file.Write(key)
+        _, err = file.Write(key)
+        if err != nil {
+            fmt.Fprintln(os.Stderr, "Failed to write authorized_keys file to "+path)
+            return
+        }
 
         // Change the file permissions to 600
         err = file.Chmod(0600)

--- a/config.toml
+++ b/config.toml
@@ -11,3 +11,11 @@ pubkey = """
 # Whether to accept data from an AKDS record if it fails verification
 # Missing signatures on AKDS records will always produce an error
 acceptUnverified = false
+
+# Whether to overwrite authorized_keys with AKD/S results
+overwriteAuthorizedKeys = false
+
+# Path to authorized_keys
+# Relative paths are relative to this config file
+# Only applies if overwriteAuthorizedKeysFile is set to true
+authorizedKeysPath = "authorized_keys"


### PR DESCRIPTION
Adds an option to write out keys to a particular file (typically `~/.ssh/authorized_keys`, configurable in the config file).

The file will only be written if the keys are successfully validated. If AKDS is enabled it will also require successful signature validation.

Closes #2