### PR TITLE
Add URL query

### DIFF
--- a/akd-client.go
+++ b/akd-client.go
@@ -67,7 +67,7 @@ func loadConfig(path string) (Config, error) {
 
     // Ensure we've been given either a record name or URL
     if config.RecordName == "" && config.Url == "" {
-        return config, errors.New("No value for RecordName or Url provided, cannot retrieve any keys")
+        return config, errors.New("No value for RecordName or Url provided, will not be able to retrieve any keys")
     }
 
     // Parse the pubkey if we've been given one

--- a/config.toml
+++ b/config.toml
@@ -12,6 +12,13 @@ pubkey = """
 # Missing signatures on AKDS records will always produce an error
 acceptUnverified = false
 
+# URL to pull keys from
+# Note that the response is pulled as-is and will not be verified, unlike AKDS
+url = "https://example.com/keys"
+
+# Whether to allow fallback to pulling keys from URL if AKD/S fails
+allowUrlFallback = true
+
 # Whether to overwrite authorized_keys with AKD/S results
 overwriteAuthorizedKeys = false
 


### PR DESCRIPTION
Adds a pair of config options that specify a URL to pull keys from and whether to allow fallback to URL if AKD/S fails.

## Config entries
This adds the following new config entries:
- `url`: The URL to pull keys from
- `allowUrlFallback`: Whether to allow pulling keys from `url` if pulling from AKD/S fails

Closes #4 