### PR TITLE
Add exit codes

### DIFF
--- a/akd-client.go
+++ b/akd-client.go
@@ -22,11 +22,11 @@ import (
 // Exit codes
 const (
     exitNoError = 0
-    exitGenericError = 1
+    //exitGenericError = 1
     exitConfigError = 2
     exitGetKeyError = 3
     exitValidationError = 4
-    exitIOError = 5
+    //exitIOError = 5
 )
 
 // Config file format

--- a/config.toml
+++ b/config.toml
@@ -26,3 +26,8 @@ overwriteAuthorizedKeys = false
 # Relative paths are relative to this config file
 # Only applies if overwriteAuthorizedKeysFile is set to true
 authorizedKeysPath = "authorized_keys"
+
+# Whether failure to write out the authorized_keys file will cause a non-zero exit code
+# Be careful with this! If key validation was successful but the file fails, login will
+# be denied by OpenSSH!
+raiseAuthorizedKeysErrors = false


### PR DESCRIPTION
Adds non-zero exit codes on failure rather than simply returning.

OpenSSH will treat a non-zero exit code as a command failure, so the only hard failures are those leading up to the keys being printed to stdout.

Non-zero exits after printing the keys can be toggled on or off through the `raiseAuthorizedKeysErrors` config option.